### PR TITLE
require/1s appear multiply rather than using a list 

### DIFF
--- a/pack.pl
+++ b/pack.pl
@@ -7,4 +7,4 @@ packager('Edison Mera Menendez', 'http://www.edisonm.com/').
 maintainer('Edison Mera Menendez', 'http://www.edisonm.com/').
 home('https://github.com/edisonm/xlibrary').
 download('https://github.com/edisonm/xlibrary.git').
-requires([lambda]).
+requires(lambda).


### PR DESCRIPTION
require/1s appear multiply rather than using a list

this unbreaks  `?- pack_list_installed.`
